### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -82,7 +82,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     restart: always
     healthcheck:
       test: "redis-cli -a '${REDIS_PASSWORD}' ping | grep PONG"
@@ -94,7 +94,7 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
 
   limiter_redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     restart: always
     healthcheck:
       test: "redis-cli -a '${LIMITER_REDIS_PASSWORD}' ping | grep PONG"

--- a/docker-compose.test.services.yml
+++ b/docker-compose.test.services.yml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_PASSWORD=pass
 
   redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     healthcheck:
       test: "redis-cli -a 'pass' ping | grep PONG"
       start_period: "5s"
@@ -25,7 +25,7 @@ services:
       REDIS_PASSWORD: pass
 
   limiter_redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     healthcheck:
       test: "redis-cli -a 'pass' ping | grep PONG"
       start_period: "5s"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - POSTGRES_PASSWORD=pass
 
   redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     healthcheck:
       test: "redis-cli -a 'pass' ping | grep PONG"
       start_period: "5s"
@@ -39,7 +39,7 @@ services:
       REDIS_PASSWORD: pass
 
   limiter_redis:
-    image: bitnami/redis:6.2
+    image: soldevelo/redis:6.2
     healthcheck:
       test: "redis-cli -a 'pass' ping | grep PONG"
       start_period: "5s"


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/redis:6.2` → [`soldevelo/redis:6.2`](https://hub.docker.com/r/soldevelo/redis)