### PR TITLE
Expose Docker image tag names at /up endpoint

### DIFF
--- a/.github/workflows/docker-build-push-v2.yml
+++ b/.github/workflows/docker-build-push-v2.yml
@@ -21,6 +21,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
       -
+        name: Extract tag names
+        id: tag_names
+        run: |
+          names=$(echo "${{ steps.docker_meta.outputs.tags }}" | sed 's/.*://' | paste -sd, -)
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       -
@@ -40,6 +46,8 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
+          build-args: |
+            APP_TAGS=${{ steps.tag_names.outputs.names }}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ ENV REDIS_URL=""
 ENV LIMITER_REDIS_URL=""
 ENV DOCS_URL=""
 
+# Docker image tag names (comma-separated), populated by the docker-build-push
+# workflow build-arg and exposed at runtime (see the /up endpoint).
+ARG APP_TAGS=""
+ENV APP_TAGS=${APP_TAGS}
+
 # Install pip requirements
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -47,6 +47,10 @@ def load_app_config_from_env(app: Flask):
     app.config["FLASK_DEBUG"] = getenv_bool("FLASK_DEBUG", "False")
     app.config["API_READ_ANONYM"] = getenv_bool("API_READ_ANONYM", "False")
 
+    # Docker image tag names (comma-separated) baked into the image at build
+    # time (see Dockerfile build-arg populated by the docker-build-push workflow).
+    app.config["APP_TAGS"] = os.getenv("APP_TAGS", "")
+
     if os.getenv("PREFERRED_URL_SCHEME"):  # pragma: no cover
         app.config["PREFERRED_URL_SCHEME"] = os.getenv("PREFERRED_URL_SCHEME")
 

--- a/project/views/root.py
+++ b/project/views/root.py
@@ -4,6 +4,7 @@ import os.path
 from flask import (
     abort,
     current_app,
+    jsonify,
     render_template,
     request,
     send_from_directory,
@@ -60,7 +61,14 @@ def up():
         if hasattr(storage, "ping"):
             storage.ping()
 
-    return "OK"
+    tags = current_app.config.get("APP_TAGS", "")
+
+    return jsonify(
+        {
+            "status": "OK",
+            "tag-names": [tag for tag in tags.split(",") if tag],
+        }
+    )
 
 
 @main_bp.route("/tos")


### PR DESCRIPTION
## Summary

Expose the Docker image tag names at the `/up` health endpoint so a running container can report which image version(s) it was built from.

`GET /up` now returns:

```json
{
  "status": "OK",
  "tag-names": [
    "0.55.1",
    "0.55",
    "sha-1dbbe1c",
    "latest"
  ]
}
```

## Changes

- **`.github/workflows/docker-build-push-v2.yml`** — new "Extract tag names" step turns `docker/metadata-action`'s `tags` output (full refs like `eventcally/eventcally:0.55.1`) into a comma-separated list of bare tag names, passed as the `APP_TAGS` build-arg.
- **`Dockerfile`** — `ARG APP_TAGS` → `ENV APP_TAGS` so the value persists at runtime.
- **`project/__init__.py`** — load `APP_TAGS` into app config.
- **`project/views/root.py`** — `/up` keeps its DB/Redis/limiter health-check pings and now returns the `tag-names` list (split from `APP_TAGS`).

## Notes

- Health-check consumers (`docker-compose.yml`, `deployment/.../docker-compose.yml`) use `curl -f`, so only the 200 status matters — the richer body is backwards compatible.
- When `APP_TAGS` is unset (local/dev), `tag-names` is an empty list.
- `latest` appears automatically via `metadata-action`'s default `latest=auto` flavor on non-prerelease semver pushes.

## Testing

- `tests/views/test_root.py::test_up` passes.
- Manually exercised `create_app().test_client().get('/up')` with `APP_TAGS="0.55.1,0.55,sha-1dbbe1c,latest"` → 200 with the expected `tag-names` list.

Fixes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)
