### PR TITLE
Redirect anonymous users to login on /manage/admin_unit/ links

### DIFF
--- a/project/access.py
+++ b/project/access.py
@@ -234,6 +234,10 @@ def get_admin_unit_for_manage_or_404(admin_unit_id):
     admin_unit = get_admin_unit_for_manage(admin_unit_id)
 
     if not admin_unit:
+        if not current_user.is_authenticated:
+            # Anonymous users following e.g. an email link should be sent to
+            # login (with a `next` back to the original page), not shown a 404.
+            abort(current_app.login_manager.unauthorized())
         abort(404)
 
     return admin_unit

--- a/tests/views/test_manage.py
+++ b/tests/views/test_manage.py
@@ -89,6 +89,17 @@ def test_admin_unit(client, seeder: Seeder, utils: UtilActions):
     )
 
 
+def test_admin_unit_child_route_not_authenticated_redirects_to_login(
+    client, seeder: Seeder, utils: UtilActions
+):
+    _, admin_unit_id = seeder.setup_base(log_in=False)
+
+    url = utils.get_url("manage_admin_unit.events", id=admin_unit_id)
+    response = client.get(url)
+
+    utils.assert_response_redirect_to_login(response, url)
+
+
 def test_admin_unit_404(client, seeder: Seeder, utils: UtilActions):
     owner_id = seeder.create_user("owner@owner")
     admin_unit_id = seeder.create_admin_unit(owner_id, "Other crew")

--- a/tests/views/test_reference_request_review.py
+++ b/tests/views/test_reference_request_review.py
@@ -171,7 +171,7 @@ def test_review_status_404_third(client, seeder, utils):
     assert response.status_code == 404
 
 
-def test_review_status_404_unauthorized(client, seeder, utils):
+def test_review_status_unauthorized_redirects_to_login(client, seeder, utils):
     seeder.create_user()
 
     third_user_id = seeder.create_user("third@third.de")
@@ -189,4 +189,4 @@ def test_review_status_404_unauthorized(client, seeder, utils):
         event_reference_request_id=reference_request_id,
     )
     response = client.get(url)
-    assert response.status_code == 404
+    utils.assert_response_redirect_to_login(response, url)

--- a/tests/views/test_verification_request_review.py
+++ b/tests/views/test_verification_request_review.py
@@ -157,7 +157,9 @@ def test_review_reject(client, seeder: Seeder, utils: UtilActions, app, db, mock
         assert verification_request.rejection_reason is None
 
 
-def test_review_status_404(client, seeder: Seeder, utils: UtilActions):
+def test_review_status_unauthorized_redirects_to_login(
+    client, seeder: Seeder, utils: UtilActions
+):
     seeder.create_user()
 
     third_user_id = seeder.create_user("third@third.de")
@@ -182,4 +184,4 @@ def test_review_status_404(client, seeder: Seeder, utils: UtilActions):
     utils.assert_response_redirect_to_url(client.get(legacy_review_url), url)
 
     response = client.get(url)
-    assert response.status_code == 404
+    utils.assert_response_redirect_to_login(response, url)


### PR DESCRIPTION
## Summary

Clicking a `/manage/admin_unit/…` email link (e.g. `.../incoming_event_reference/3695`) while **logged out** returned a **404** instead of redirecting to the login page.

**Root cause:** the `manage_admin_unit_bp` URL-value preprocessor resolves the admin unit via `get_admin_unit_for_manage_or_404(id)` *before* the view's `auth_required()` decorator runs. For anonymous users `get_admin_units_for_manage()` returns `[]`, so the helper called `abort(404)` before login enforcement got a chance.

**Fix:** in `get_admin_unit_for_manage_or_404`, redirect anonymous users to login via `current_app.login_manager.unauthorized()` (which builds the correct relative `next` back to the requested page), while keeping the 404 for *authenticated* users without access (no existence leak). Because the fix lives in the shared resolver called by the parent blueprint's preprocessor, it corrects the entire `/manage/admin_unit/**` route tree in one place.

## Behavior

- Anonymous `GET /manage/admin_unit/<id>/…` → **302 → login** with `next` = requested URL (was 404).
- After login, the user lands on the originally requested page.
- Authenticated user without access → still **404** (uniform, no existence leak).

## Tests

- Added `test_admin_unit_child_route_not_authenticated_redirects_to_login` — drives the real route through the test client, hitting the exact preprocessor path.
- `test_admin_unit_404` still passes (authenticated-no-access → 404).
- Full `tests/views/test_manage.py` suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)